### PR TITLE
Bluetooth player lite

### DIFF
--- a/install/etc/asound.conf
+++ b/install/etc/asound.conf
@@ -1,0 +1,4 @@
+defaults.bluealsa.interface "hci0"
+defaults.bluealsa.device "XX:XX:XX:XX:XX:XX"
+defaults.bluealsa.profile "a2dp"
+defaults.bluealsa.delay 10000

--- a/install/install.sh
+++ b/install/install.sh
@@ -5,7 +5,7 @@ fi
 
 ln -s /home/pi/mpradio/src/mpradio.py /home/pi/mpradio.py
 
-apt-get -y install git libsndfile1-dev libbluetooth-dev bluez pi-bluetooth python-gobject python-gobject-2 bluez-tools sox ffmpeg libsox-fmt-mp3 python-dbus bluealsa obexpushd python3-rpi.gpio python3-mutagen python3-dbus python3-pip python3-dev pkg-config
+apt-get -y install git libsndfile1-dev libbluetooth-dev bluez pi-bluetooth python-gobject python-gobject-2 bluez-tools sox ffmpeg libsox-fmt-mp3 python-dbus bluealsa obexpushd python3-rpi.gpio python3-mutagen python3-dbus python3-pip python3-dev pkg-config python3-pyaudio
 
 # pyav specific dependencies:
 apt-get install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev

--- a/install/install.sh
+++ b/install/install.sh
@@ -71,4 +71,9 @@ echo PRETTY_HOSTNAME=mpradio > /etc/machine-info
 # avoid recompilation (by need2recompile.service) after first install 
 cp -f /sys/firmware/devicetree/base/model /etc/lastmodel
 
+echo "these modules might cause trouble with audio sampling rate"
+echo "please blacklist them if you haven't already:"
+echo "echo \"blacklist snd_bcm2835\" >> /etc/modprobe.d/blacklist.conf"
+echo "echo \"blacklist ipv6\" >> /etc/modprobe.d/blacklist.conf"
+
 sleep 5 && reboot

--- a/install/usr/lib/udev/bluetooth
+++ b/install/usr/lib/udev/bluetooth
@@ -21,6 +21,7 @@ then
 		BTMAC=$(a2dp_connected.py)
 	fi
 
+	sed -i "s/^defaults.bluealsa.device.*$/defaults.bluealsa.device \"$BTMAC\"/g" /etc/asound.conf
 	echo "bluetooth attach $BTMAC" > /tmp/mpradio_bt
 else
         log "Other action " $ACTION

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -56,8 +56,8 @@ class BtPlayerLite(Player):
 
         sample_rate = int(dev['defaultSampleRate'])
         in_channels = 2
-        in_fmt = pyaudio.paInt24  # probabilmente anche 16 will do
-        CHUNK = 512
+        in_fmt = pyaudio.paInt16
+        CHUNK = 64
 
         audio_stream = self.p.open(sample_rate, channels=in_channels, format=in_fmt, input=True,
                                    input_device_index=dev['index'], frames_per_buffer=CHUNK)
@@ -73,7 +73,7 @@ class BtPlayerLite(Player):
 
         while not self.__terminating:
             data = audio_stream.read(CHUNK)
-            container.writeframes(b''.join(data))
+            container.writeframesraw(data)
 
         # close output container and tell the buffer no more data is coming
         container.close()

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -1,0 +1,144 @@
+import dbus
+from player import Player
+import subprocess
+import av
+from mp_io import MpradioIO
+from rds import RdsUpdater
+import time
+import threading
+import pyaudio
+
+class BtPlayerLite(Player):
+
+    __bt_addr = None
+    __cmd_arr = None
+    __rds_updater = None
+    __now_playing = None
+    output_stream = None
+    __terminating = False
+    CHUNK = 1024 * 64   # Pi0 on integrated bluetooth seem to work best with 64k chunks
+
+    def __init__(self, bt_addr):
+        super().__init__()
+        self.__rds_updater = RdsUpdater()
+        self.__bt_addr = bt_addr
+        self.__cmd_arr = ["sudo", "dbus-send", "--system", "--type=method_call", "--dest=org.bluez", "/org/bluez/hci0/dev_"
+                          + bt_addr.replace(":", "_").upper() + "/player0", "org.bluez.MediaPlayer1.Pause"]
+
+        self.p = pyaudio.PyAudio()
+
+    def playback_position(self):
+        pass
+
+    def resume(self):
+        self.__cmd_arr[len(self.__cmd_arr) - 1] = "org.bluez.MediaPlayer1.Play"
+        subprocess.call(self.__cmd_arr)
+
+    def run(self):
+        threading.Thread(target=self.__run).start()
+
+    def __run(self):
+        print("playing bluetooth:", self.__bt_addr)
+        dev = "bluealsa:HCI=hci0,DEV="+self.__bt_addr
+        self.__rds_updater.run()
+        while not self.__terminating:
+            self.play(dev)
+            time.sleep(1)
+
+    def play(self, device):
+        # open input device
+        dev = None
+        for i in range(p.get_device_count()):
+            if p.get_device_info_by_index(i)['name'] == 'bluealsa':
+                dev = p.get_device_info_by_index(i)
+
+        sample_rate = int(dev['defaultSampleRate'])
+        in_channels = 2
+        in_fmt = pyaudio.paInt24  # probabilmente anche 16 will do
+        CHUNK = 512
+
+        audio_stream = self.p.open(sample_rate, channels=in_channels, format=in_fmt, input=True,
+                                   input_device_index=dev['index'], frames_per_buffer=CHUNK)
+
+        # open output stream
+        self.output_stream = MpradioIO()
+
+        while not self.__terminating:
+            data = audio_stream.read(CHUNK)
+            self.output_stream.write(data)
+
+
+        # close output container and tell the buffer no more data is coming
+        audio_stream.stop_stream()
+        audio_stream.close()
+        self.p.terminate()
+
+        self.output_stream.set_write_completed()
+
+        # TODO: check if this and the above is really needed when playing a device
+        # wait until playback (buffer read) terminates; catch signals meanwhile
+        while not self.output_stream.is_read_completed():
+            if self.__terminating:
+                break
+            time.sleep(0.2)
+
+    def get_now_playing(self):
+        try:
+            bus = dbus.SystemBus()
+            player = bus.get_object("org.bluez", "/org/bluez/hci0/dev_" + self.__bt_addr.replace(":", "_").upper()
+                                    + "/player0")
+            BT_Media_iface = dbus.Interface(player, dbus_interface="org.bluez.MediaPlayer1")
+            BT_Media_probs = dbus.Interface(player, "org.freedesktop.DBus.Properties")
+            probs = BT_Media_probs.GetAll("org.bluez.MediaPlayer1")
+
+            self.__now_playing = dict()
+            self.__now_playing["title"] = probs["Track"]["Title"]
+            self.__now_playing["artist"] = probs["Track"]["Artist"]
+            self.__now_playing["album"] = probs["Track"]["Album"]
+        except dbus.DBusException:
+            pass
+        except KeyError:
+            self.__now_playing = None
+
+    def pause(self):
+        self.__cmd_arr[len(self.__cmd_arr) - 1] = "org.bluez.MediaPlayer1.Pause"
+        subprocess.call(self.__cmd_arr)
+
+    def next(self):
+        self.__cmd_arr[len(self.__cmd_arr) - 1] = "org.bluez.MediaPlayer1.Next"
+        subprocess.call(self.__cmd_arr)
+
+    def previous(self):
+        self.__cmd_arr[len(self.__cmd_arr) - 1] = "org.bluez.MediaPlayer1.Previous"
+        subprocess.call(self.__cmd_arr)
+
+    def repeat(self):
+        self.__cmd_arr[len(self.__cmd_arr) - 1] = "org.bluez.MediaPlayer1.Repeat"
+        subprocess.call(self.__cmd_arr)
+
+    def fast_forward(self):
+        pass
+
+    def rewind(self):
+        pass
+
+    def stop(self):
+        self.output_stream.silence(True)
+        self.__rds_updater.stop()
+        self.__terminating = True
+        time.sleep(1)
+        self.output_stream.stop()
+        print("bluetooth player stopped")
+
+    def song_name(self):
+        return self.__now_playing["title"]
+
+    def song_artist(self):
+        return self.__now_playing["artist"]
+
+    def song_year(self):
+        return self.__now_playing["year"]
+
+    def song_album(self):
+        return self.__now_playing["album"]
+

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -72,7 +72,7 @@ class BtPlayerLite(Player):
         self.ready.set()
 
         while not self.__terminating:
-            data = audio_stream.read(CHUNK)
+            data = audio_stream.read(CHUNK, False)
             container.writeframesraw(data)
 
         # close output container and tell the buffer no more data is coming

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -62,9 +62,11 @@ class BtPlayerLite(Player):
         # 44100 frames per second means 176400 bytes per second or 1411.2 Kbps
         sample_rate = 44100
 
-        # How many frames to read each time. for 44100 Hz 44,1 is 1ms equivalent
-        frame_chunk = 441  # 10ms audio coverage per iteration
-        self.CHUNK = frame_chunk * 4  # bytes to read cycle
+        buffer_time = 20  # 20ms audio coverage per iteration
+
+        # How many frames to read each time. for 44100Hz 44,1 is 1ms equivalent
+        frame_chunk = int((sample_rate/1000) * buffer_time)
+        self.CHUNK = frame_chunk * 4  # bytes to read at each cycle
 
         # This will setup the stream to read CHUNK frames
         audio_stream = self.p.open(sample_rate, channels=in_channels, format=in_fmt, input=True,

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -68,15 +68,16 @@ class BtPlayerLite(Player):
         frame_chunk = int((sample_rate/1000) * buffer_time)
         self.CHUNK = frame_chunk * 4  # bytes to read at each cycle
 
-        # Make sure the consumer will wait enough for us to write new data before reading, but avoid stuttering
-        self.output_stream.chunk_sleep_time = (buffer_time/2)
-
         # This will setup the stream to read CHUNK frames
         audio_stream = self.p.open(sample_rate, channels=in_channels, format=in_fmt, input=True,
                                    input_device_index=dev['index'], frames_per_buffer=frame_chunk)
 
         # open output stream
         self.output_stream = MpradioIO()
+
+        # Make sure the consumer will wait enough for us to write new data before reading, but avoid stuttering
+        self.output_stream.chunk_sleep_time = int((buffer_time * 0.001)/2)
+
         container = wave.open(self.output_stream, 'wb')
         container.setnchannels(in_channels)
         container.setsampwidth(self.p.get_sample_size(in_fmt))

--- a/src/bluetooth_player_lite.py
+++ b/src/bluetooth_player_lite.py
@@ -68,6 +68,9 @@ class BtPlayerLite(Player):
         frame_chunk = int((sample_rate/1000) * buffer_time)
         self.CHUNK = frame_chunk * 4  # bytes to read at each cycle
 
+        # Make sure the consumer will wait enough for us to write new data before reading, but avoid stuttering
+        self.output_stream.chunk_sleep_time = (buffer_time/2)
+
         # This will setup the stream to read CHUNK frames
         audio_stream = self.p.open(sample_rate, channels=in_channels, format=in_fmt, input=True,
                                    input_device_index=dev['index'], frames_per_buffer=frame_chunk)

--- a/src/mp_io.py
+++ b/src/mp_io.py
@@ -33,7 +33,7 @@ class MpradioIO(io.BytesIO):
 
             if len(result) < 1:
                 # print("MpradioIO error: read 0 bytes.")
-                time.sleep(0.01)
+                time.sleep(0.02)    # TODO: maybe align it to bluetooth player buffer time?
                 if self.__terminating:
                     break
             else:

--- a/src/mpradio.py
+++ b/src/mpradio.py
@@ -7,6 +7,7 @@ from encoder import Encoder
 from configuration import config    # must be imported before all other modules (dependency)
 from bluetooth_remote import BtRemote
 from bluetooth_player import BtPlayer
+from bluetooth_player_lite import BtPlayerLite
 from fm_output import FmOutput
 from analog_output import AnalogOutput
 from storage_player import StoragePlayer
@@ -127,15 +128,15 @@ class Mpradio:
                         self.bt_remote.reply(result)
                 elif cmd[0] == "bluetooth":
                     if cmd[1] == "attach":
-                        if self.player.__class__.__name__ == "BtPlayer":
+                        if self.player.__class__.__name__ == "BtPlayerLite":
                             continue
-                        tmp = BtPlayer(cmd[2])
+                        tmp = BtPlayerLite(cmd[2])
                         self.player.stop()
                         self.player = tmp
                         self.player.run()
                         print("bluetooth attached")
                     elif cmd[1] == "detach":
-                        if self.player.__class__.__name__ != "BtPlayer":
+                        if self.player.__class__.__name__ != "BtPlayerLite":
                             continue
                         tmp = StoragePlayer()
                         tmp.run()

--- a/src/mpradio.py
+++ b/src/mpradio.py
@@ -89,19 +89,11 @@ class Mpradio:
         # play stream
         while True:
             try:
-                if data is not None:
-                    self.encoder.ready.wait()
-                    self.encoder.input_stream.write(data)
-                else:
-                    # print("waiting for player data")
-                    raise AttributeError
-                self.encoder.ready.wait()
-                encoded = self.encoder.output_stream.read(self.player.CHUNK)
-                if encoded is not None:                             # send the encoded data to output, if any
+                if data is not None:                             # send the encoded data to output, if any
                     self.output.ready.wait()
-                    self.output.input_stream.write(encoded)
+                    self.output.input_stream.write(data)
                 else:
-                    # print("waiting for encoder data")
+                    print("waiting for player data")
                     raise AttributeError
             except AttributeError:
                 time.sleep(self.player.SLEEP_TIME)                  # avoid 100% CPU when player is paused

--- a/src/mpradio.py
+++ b/src/mpradio.py
@@ -88,15 +88,9 @@ class Mpradio:
 
         # play stream
         while True:
-            try:
-                if data is not None:                             # send the encoded data to output, if any
-                    self.output.ready.wait()
-                    self.output.input_stream.write(data)
-                else:
-                    print("waiting for player data")
-                    raise AttributeError
-            except AttributeError:
-                time.sleep(self.player.SLEEP_TIME)                  # avoid 100% CPU when player is paused
+            if data is not None:
+                self.output.ready.wait()
+                self.output.input_stream.write(data)
             # advance the "play head"
             self.player.ready.wait()
             data = self.player.output_stream.read(self.player.CHUNK)


### PR DESCRIPTION
BtPlayerLite is a lightweight bluetooth player based on portaudio. It provides no eq out of the box, but drammatically improves performance and delay time over the ffmpeg implementation.
